### PR TITLE
Return status 401 if the Authorization header is missing

### DIFF
--- a/lib/resty/hawk.lua
+++ b/lib/resty/hawk.lua
@@ -93,7 +93,7 @@ end
 local function parse_authorization_header(auth_header, allowable_keys)
 	local ngx = ngx
 	if not auth_header then
-		return exit(ngx.HTTP_FORBIDDEN, "No auth header")
+		return exit(ngx.HTTP_UNAUTHORIZED, "No auth header")
 	end
 
 	if not allowable_keys then


### PR DESCRIPTION
Currently status 403 (Forbidden) is returned.  However, the usual use of status 401 is to indicate that an Authorization header was expected, so 401 seems more appropriate here.
